### PR TITLE
Fix serving of SVG images over custom protocol

### DIFF
--- a/app/electron/protocol.js
+++ b/app/electron/protocol.js
@@ -25,7 +25,7 @@ const mimeTypes = {
   ".htm": "text/html",
   ".json": "application/json",
   ".css": "text/css",
-  ".svg": "application/svg+xml",
+  ".svg": "image/svg+xml",
   ".ico": "image/vnd.microsoft.icon",
   ".png": "image/png",
   ".jpg": "image/jpeg",


### PR DESCRIPTION
Took me some time to figure out why SVG symbols weren't rendering in our application even though the file was correctly being resolved and contents returned.

Turned out to be the mime type.
There is an [anecdotal case](https://stackoverflow.com/questions/11918977/right-mime-type-for-svg-images-with-fonts-embedded) of a warning being printed if the svg in question is a webfont, but for svg images it should be `image/svg+xml`.