### PR TITLE
fix(protocol.js): wrong input type in charset() call

### DIFF
--- a/app/electron/protocol.js
+++ b/app/electron/protocol.js
@@ -32,15 +32,16 @@ const mimeTypes = {
   ".map": "text/plain"
 };
 
-function charset(mimeType) {
-  return [".html", ".htm", ".js", ".mjs"].some((m) => m === mimeType) ?
+function charset(mimeExt) {
+  return [".html", ".htm", ".js", ".mjs"].some((m) => m === mimeExt) ?
     "utf-8" :
     null;
 }
 
 function mime(filename) {
-  const type = mimeTypes[path.extname(`${filename || ""}`).toLowerCase()];
-  return type ? type : null;
+  const mimeExt = path.extname(`${filename || ""}`).toLowerCase();
+  const mimeType = mimeTypes[mimeExt];
+  return mimeType ? { mimeExt, mimeType } : { mimeExt: null, mimeType: null };
 }
 
 function requestHandler(req, next) {
@@ -51,12 +52,12 @@ function requestHandler(req, next) {
   }
   const reqFilename = path.basename(reqPath);
   fs.readFile(path.join(DIST_PATH, reqPath), (err, data) => {
-    const mimeType = mime(reqFilename);
+    const { mimeExt, mimeType } = mime(reqFilename);
     if (!err && mimeType !== null) {
       next({
-        mimeType: mimeType,
-        charset: charset(mimeType),
-        data: data
+        mimeType,
+        charset: charset(mimeExt),
+        data
       });
     } else {
       console.error(err);


### PR DESCRIPTION
## Overview
- Hey, first of all thanks so much for your work on this template. I'm still trying to get it to work with typescript with my preferred configurations, but otherwise it's a great scaffolding tool that just works without compromising security best practices. 
- I came across what seems like a minor logical error in the code, and wrote a simple fix. 
- My changes do not cause any apparent issues with `npm test`, `npm run dev`, `npm run prod`, `npm run dist` in node v16.
  - Cannot get mocha test to run successfully in node v17 with the original template, but will investigate some more and create a separate issue for this if I can't find a solution. 
- It is entirely possible that I misunderstood your intent and this isn't a bug at all, in which case you're more than welcome to just close the PR.  
- System info: `Darwin Kernel Version 21.2.0; root:xnu-8019.61.5~1/RELEASE_ARM64_T8101 arm64`

## Details
- The input parameter for charset() is of type `keyof typeof mimeTypes` i.e. union of all keys of the mimeTypes object.
- However, in the charset() function call in requestHandler() (line 59), mimeType is being passed in, despite being of type `string | null` i.e. ReturnType of mime().
- Established naming convention of 'mimeExt' for keys of the mimeTypes object, and 'mimeType' for its values to minimize potential for confusion.