### PR TITLE
Enable i18next translations in newly created windows from Renderer pr…

### DIFF
--- a/app/electron/main.js
+++ b/app/electron/main.js
@@ -266,7 +266,10 @@ app.on("web-contents-created", (event, contents) => {
     // Disable Node.js integration
     webPreferences.nodeIntegration = false;
   });
-
+  // enable i18next translations in popup window
+  contents.on("did-create-window", (window) => {
+    i18nextBackend.mainBindings(ipcMain, window, fs);
+  });
   // https://electronjs.org/docs/tutorial/security#13-disable-or-limit-creation-of-new-windows
   // This code replaces the old "new-window" event handling;
   // https://github.com/electron/electron/pull/24517#issue-447670981

--- a/app/electron/main.js
+++ b/app/electron/main.js
@@ -270,6 +270,11 @@ app.on("web-contents-created", (event, contents) => {
   contents.on("did-create-window", (window) => {
     i18nextBackend.mainBindings(ipcMain, window, fs);
   });
+  // destroy bindings on popup window closed
+  contents.on("destroyed", () => {
+    i18nextBackend.clearMainBindings(ipcMain);
+  });
+  
   // https://electronjs.org/docs/tutorial/security#13-disable-or-limit-creation-of-new-windows
   // This code replaces the old "new-window" event handling;
   // https://github.com/electron/electron/pull/24517#issue-447670981


### PR DESCRIPTION
Enable i18next translations in newly created windows from Renderer process.
Without this code the newly created window is stuck on loading.